### PR TITLE
Extend RequestHandler for async-await syntax compatibility

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,5 @@ In the list of contributing to the codebase:
 - Matthias Rebel < matthias.rebel at retresco de >
 
 - Fabian Neumann < mail at fabianneumann de >
+
+- Michael Jurke < michael.jurke at retresco de >

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ In order of contribution:
 * Tobias Guenther `@tobigue_ <http://twitter.com/tobigue_>`_
 * Matthias Rebel `@_rebeling <http://twitter.com/_rebeling>`_
 * Fabian Neumann `@hellp <http://twitter.com/hellp>`_
+* Michael Jurke `@mjrk <https://github.com/mjrk>`_
 
 
 License

--- a/supercell/requesthandler.py
+++ b/supercell/requesthandler.py
@@ -22,6 +22,7 @@ from datetime import datetime
 import json
 import logging
 import time
+import inspect
 
 from schematics.models import Model
 from schematics.exceptions import BaseError
@@ -224,7 +225,7 @@ class RequestHandler(rq):
 
             method = getattr(self, self.request.method.lower())
             result = method(*self.path_args, **self.path_kwargs)
-            if is_future(result):
+            if is_future(result) or inspect.iscoroutinefunction(method):
                 result = yield result
             if result is not None:
                 self._provide_result(verb, headers, result)

--- a/supercell/service.py
+++ b/supercell/service.py
@@ -133,7 +133,7 @@ class Service(object):
 
         def stop_loop():
             now = time.time()
-            if now < dl and (io_loop._callbacks or io_loop._timeouts):
+            if now < dl and self._has_callbacks(io_loop):
                 io_loop.add_timeout(now + 1, stop_loop)
             else:
                 io_loop.stop()
@@ -286,3 +286,16 @@ class Service(object):
         """Implement this method in order to add handlers and managed objects
         to the environment, before the app is started."""
         pass
+
+    def _has_callbacks(self, io_loop):
+        """Check if the io_loop has pending callbacks.
+
+        The check works with the default io_loop as well as the asyncio loop.
+        You may have to override it for other implemations.
+        """
+        if hasattr(tornado.platform, "asyncio") and isinstance(
+            io_loop, tornado.platform.asyncio.AsyncIOMainLoop
+        ):
+            return io_loop.asyncio_loop._scheduled
+        else:
+            return (io_loop._callbacks or io_loop._timeouts)

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -153,11 +153,14 @@ class ServiceTest(TestCase):
         if sys.version_info < (3,):
             expected.extend([mock.call(), mock.call().remove_handler(mock.ANY),
                              mock.call()._callbacks.__nonzero__(),
+                             mock.call()._callbacks.__nonzero__(),
                              mock.call().add_timeout(mock.ANY, mock.ANY)])
         else:
             expected.extend([mock.call(), mock.call().remove_handler(mock.ANY),
                              mock.call()._callbacks.__bool__(),
+                             mock.call()._callbacks.__bool__(),
                              mock.call().add_timeout(mock.ANY, mock.ANY)])
+
         assert expected == ioloop_instance_mock.mock_calls
 
     @mock.patch('tornado.ioloop.IOLoop.instance')


### PR DESCRIPTION
Yield coroutines (created with async syntax) as well as futures